### PR TITLE
Add seattlelib v2

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -1,5 +1,6 @@
 ./*
 DEPENDENCIES/repy_v2/*
 DEPENDENCIES/common/*
+DEPENDENCIES/seattlelib_v2/*
 # Tests
 test ./tests/*

--- a/scripts/config_initialize.txt
+++ b/scripts/config_initialize.txt
@@ -1,2 +1,3 @@
 https://github.com/SeattleTestbed/repy_v2 ../DEPENDENCIES/repy_v2
 https://github.com/SeattleTestbed/common ../DEPENDENCIES/common
+https://github.com/SeattleTestbed/seattlelib_v2 ../DEPENDENCIES/seattlelib_v2


### PR DESCRIPTION
Issue #55: Testing "utf" reveals missing dependencies.

Issue has been fixed. For this, I added Dependencies of seatllelib_v2 to config_build.txt and config_initialize.txt.

Testing instructions and resulting output are as follows:
````
Microsoft Windows [Version 6.3.9600]
(c) 2013 Microsoft Corporation. All rights reserved.

C:\Users\Pbijv>cd "C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\scripts"

C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\scripts>python initialize.py
Checking out repo from https://github.com/SeattleTestbed/repy_v2 ...
Done!
Checking out repo from https://github.com/SeattleTestbed/common ...
Done!
Checking out repo from https://github.com/SeattleTestbed/seattlelib_v2 ...
Done!

C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\scripts>python build.py -t
Building into C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\RUNNABLE
Done building!

C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\scripts>cd ../runnable

C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\RUNNABLE>python utf.py -f ut_utfte
ts_test_pragma_repy.py
Testing module: utftests
        Running: ut_utftests_test_pragma_repy.py                    [ PASS ]

C:\Users\Pbijv\Desktop\utf-add-seattlelib_v2\RUNNABLE>
````