### PR TITLE
Sort by module names before running all tests

### DIFF
--- a/utf.py
+++ b/utf.py
@@ -345,8 +345,14 @@ def test_all(file_list, security_layers):
     else:
       module_dictionary[module] = [test_file]
   
+  # Put the modules in alphabetical order
+  # (like SeattleTestbed/ATTIC#1225)
+  module_names =  module_dictionary.keys()
+  module_names.sort()
+
   # Test each module.
-  for module_name, module_file_list in module_dictionary.iteritems():
+  for module_name in module_names:
+    module_file_list = module_dictionary[module_name]
     test_module(module_name, module_file_list, security_layers)
 
 


### PR DESCRIPTION
As described in SeattleTestbed/ATTIC#1225, it's hard to read and compare the output of `utf.py` when the names of things that are iterated over are not sorted alphabetically. This commit fixes the problem for module names in `-a` ("run all tests") mode.